### PR TITLE
Allow configurable prefix to resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ Default for default is:
 Timezone to use for scheduler. Can be 'local', 'gmt' or an Olson timezone from https://gist.github.com/ykessler/3349954. default is 'gmt'. local time is for the AWS region.
 
 ### ec2_schedule
-
 Whether to do scheduling for EC2 instances. default = "true".
 
 ### rds_schedule
-
 Whether to do scheduling for RDS instances. default = "true".
-
 
 ### security_group_ids
 list of the vpc security groups to run lambda scheduler in. Defaults to []. Usually this does not need to be specified.
 
 ### subnet_ids
 list of subnet_ids that the scheduler runs in. Defaults to []. Usually this does not need to be specified.
+
+### resource_name_prefix
+The prefix to apply to resource names. E.g. setting this to `cluster1-` will create the Lambda as `cluster1-aws-scheduler` rather than `aws-schedule`. default = "".

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Cloudwatch event rule
 resource "aws_cloudwatch_event_rule" "check-scheduler-event" {
-    name = "check-scheduler-event"
+    name = "${var.resource_name_prefix}check-scheduler-event"
     description = "check-scheduler-event"
     schedule_expression = "${var.schedule_expression}"
     depends_on = ["aws_lambda_function.scheduler_lambda"]
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_event_target" "check-scheduler-event-lambda-target" {
 
 # IAM Role for Lambda function
 resource "aws_iam_role" "scheduler_lambda" {
-    name = "scheduler_lambda"
+    name = "${var.resource_name_prefix}scheduler_lambda"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "ec2-access-scheduler" {
 }
 
 resource "aws_iam_policy" "ec2-access-scheduler" {
-    name = "ec2-access-scheduler"
+    name = "${var.resource_name_prefix}ec2-access-scheduler"
     path = "/"
     policy = "${data.aws_iam_policy_document.ec2-access-scheduler.json}"
 }
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "ec2-access-scheduler" {
 ## create custom role
 
 resource "aws_iam_policy" "scheduler_aws_lambda_basic_execution_role" {
-  name        = "scheduler_aws_lambda_basic_execution_role"
+  name        = "${var.resource_name_prefix}scheduler_aws_lambda_basic_execution_role"
   path        = "/"
   description = "AWSLambdaBasicExecutionRole"
 
@@ -106,7 +106,7 @@ data "archive_file" "aws-scheduler" {
 # AWS Lambda function
 resource "aws_lambda_function" "scheduler_lambda" {
     filename = "${data.archive_file.aws-scheduler.output_path}"
-    function_name = "aws-scheduler"
+    function_name = "${var.resource_name_prefix}aws-scheduler"
     role = "${aws_iam_role.scheduler_lambda.arn}"
     handler = "aws-scheduler.handler"
     runtime = "python2.7"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "scheduler_lambda_arn" {
   value = "${aws_lambda_function.scheduler_lambda.arn}"
 }
+
+output "scheduler_lambda_function_name" {
+  value = "${aws_lambda_function.scheduler_lambda.function_name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,8 @@ variable "subnet_ids" {
   default = []
   description = "list of subnet_ids that the scheduler runs in."
 }
+
+variable "resource_name_prefix" {
+  default = ""
+  description = "a prefix to apply to resource names created by this module."
+}


### PR DESCRIPTION
Allow you to optionally prefix AWS resource names.  Default is "" which is backward compatible.

Outputting `scheduler_lambda_function_name` to make it easier to configure expiry/lifecycle on CloudWatch Logs

```
resource "aws_cloudwatch_log_group" "scheduler_lambda_log_group" {
  name              = "/aws/lambda/${module.scheduler-lambda.scheduler_lambda_function_name}"
  retention_in_days = 7
}
```