### PR TITLE
code wants to describe RDS clusters but policy doesnt include that perm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ data "aws_iam_policy_document" "ec2-access-scheduler" {
             "ec2:StartInstances",
             "ec2:CreateTags",
             "rds:DescribeDBInstances",
+            "rds:DescribeDBClusters",
             "rds:StartDBInstance",
             "rds:StopDBInstance",
             "rds:ListTagsForResource",


### PR DESCRIPTION
Hello,
   The code tries to run Describe Clusters but the included policy doesnt include that permission.  I need to get that into the terraform module.

Thanks!