### PR TITLE
upgrade to tf 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,22 +1,22 @@
 # Cloudwatch event rule
 resource "aws_cloudwatch_event_rule" "check-scheduler-event" {
-    name = "${var.resource_name_prefix}check-scheduler-event"
-    description = "check-scheduler-event"
-    schedule_expression = "${var.schedule_expression}"
-    depends_on = ["aws_lambda_function.scheduler_lambda"]
+  name                = "${var.resource_name_prefix}check-scheduler-event"
+  description         = "check-scheduler-event"
+  schedule_expression = var.schedule_expression
+  depends_on          = [aws_lambda_function.scheduler_lambda]
 }
 
 # Cloudwatch event target
 resource "aws_cloudwatch_event_target" "check-scheduler-event-lambda-target" {
-    target_id = "check-scheduler-event-lambda-target"
-    rule = "${aws_cloudwatch_event_rule.check-scheduler-event.name}"
-    arn = "${aws_lambda_function.scheduler_lambda.arn}"
+  target_id = "check-scheduler-event-lambda-target"
+  rule      = aws_cloudwatch_event_rule.check-scheduler-event.name
+  arn       = aws_lambda_function.scheduler_lambda.arn
 }
 
 # IAM Role for Lambda function
 resource "aws_iam_role" "scheduler_lambda" {
-    name = "${var.resource_name_prefix}scheduler_lambda"
-    assume_role_policy = <<EOF
+  name               = "${var.resource_name_prefix}scheduler_lambda"
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -31,37 +31,38 @@ resource "aws_iam_role" "scheduler_lambda" {
   ]
 }
 EOF
+
 }
 
 data "aws_iam_policy_document" "ec2-access-scheduler" {
-    statement {
-        actions = [
-            "ec2:DescribeInstances",
-            "ec2:StopInstances",
-            "ec2:StartInstances",
-            "ec2:CreateTags",
-            "rds:DescribeDBInstances",
-            "rds:DescribeDBClusters",
-            "rds:StartDBInstance",
-            "rds:StopDBInstance",
-            "rds:ListTagsForResource",
-            "rds:AddTagsToResource"
-        ]
-        resources = [
-            "*",
-        ]
-    }
+  statement {
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:StopInstances",
+      "ec2:StartInstances",
+      "ec2:CreateTags",
+      "rds:DescribeDBInstances",
+      "rds:DescribeDBClusters",
+      "rds:StartDBInstance",
+      "rds:StopDBInstance",
+      "rds:ListTagsForResource",
+      "rds:AddTagsToResource",
+    ]
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "ec2-access-scheduler" {
-    name = "${var.resource_name_prefix}ec2-access-scheduler"
-    path = "/"
-    policy = "${data.aws_iam_policy_document.ec2-access-scheduler.json}"
+  name   = "${var.resource_name_prefix}ec2-access-scheduler"
+  path   = "/"
+  policy = data.aws_iam_policy_document.ec2-access-scheduler.json
 }
 
 resource "aws_iam_role_policy_attachment" "ec2-access-scheduler" {
-    role       = "${aws_iam_role.scheduler_lambda.name}"
-    policy_arn = "${aws_iam_policy.ec2-access-scheduler.arn}"
+  role       = aws_iam_role.scheduler_lambda.name
+  policy_arn = aws_iam_policy.ec2-access-scheduler.arn
 }
 
 ## create custom role
@@ -90,50 +91,51 @@ resource "aws_iam_policy" "scheduler_aws_lambda_basic_execution_role" {
     ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "basic-exec-role" {
-    role       = "${aws_iam_role.scheduler_lambda.name}"
-    policy_arn = "${aws_iam_policy.scheduler_aws_lambda_basic_execution_role.arn}"
+  role       = aws_iam_role.scheduler_lambda.name
+  policy_arn = aws_iam_policy.scheduler_aws_lambda_basic_execution_role.arn
 }
 
 # AWS Lambda need a zip file
 data "archive_file" "aws-scheduler" {
   type        = "zip"
-  source_dir = "${path.module}/package"
+  source_dir  = "${path.module}/package"
   output_path = "${path.module}/aws-scheduler.zip"
 }
 
 # AWS Lambda function
 resource "aws_lambda_function" "scheduler_lambda" {
-    filename = "${data.archive_file.aws-scheduler.output_path}"
-    function_name = "${var.resource_name_prefix}aws-scheduler"
-    role = "${aws_iam_role.scheduler_lambda.arn}"
-    handler = "aws-scheduler.handler"
-    runtime = "python3.7"
-    timeout = 300
-    source_code_hash = "${data.archive_file.aws-scheduler.output_base64sha256}"
-    vpc_config {
-      security_group_ids = "${var.security_group_ids}"
-      subnet_ids = "${var.subnet_ids}"
+  filename         = data.archive_file.aws-scheduler.output_path
+  function_name    = "${var.resource_name_prefix}aws-scheduler"
+  role             = aws_iam_role.scheduler_lambda.arn
+  handler          = "aws-scheduler.handler"
+  runtime          = "python3.7"
+  timeout          = 300
+  source_code_hash = data.archive_file.aws-scheduler.output_base64sha256
+  vpc_config {
+    security_group_ids = var.security_group_ids
+    subnet_ids         = var.subnet_ids
+  }
+  environment {
+    variables = {
+      TAG                = var.tag
+      SCHEDULE_TAG_FORCE = var.schedule_tag_force
+      EXCLUDE            = var.exclude
+      DEFAULT            = var.default
+      TIME               = var.time
+      RDS_SCHEDULE       = var.rds_schedule
+      EC2_SCHEDULE       = var.ec2_schedule
     }
-    environment {
-      variables = {
-        TAG = "${var.tag}"
-        SCHEDULE_TAG_FORCE = "${var.schedule_tag_force}"
-        EXCLUDE = "${var.exclude}"
-        DEFAULT = "${var.default}"
-        TIME = "${var.time}"
-        RDS_SCHEDULE = "${var.rds_schedule}"
-        EC2_SCHEDULE = "${var.ec2_schedule}"
-      }
-    }
+  }
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_scheduler" {
-    statement_id = "AllowExecutionFromCloudWatch"
-    action = "lambda:InvokeFunction"
-    function_name = "${aws_lambda_function.scheduler_lambda.function_name}"
-    principal = "events.amazonaws.com"
-    source_arn = "${aws_cloudwatch_event_rule.check-scheduler-event.arn}"
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.scheduler_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.check-scheduler-event.arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 output "scheduler_lambda_arn" {
-  value = "${aws_lambda_function.scheduler_lambda.arn}"
+  value = aws_lambda_function.scheduler_lambda.arn
 }
 
 output "scheduler_lambda_function_name" {
-  value = "${aws_lambda_function.scheduler_lambda.function_name}"
+  value = aws_lambda_function.scheduler_lambda.function_name
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    archive = "~> 1"
+    aws     = "~> 2"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,59 +1,59 @@
 variable "schedule_expression" {
-  default = "cron(5 * * * ? *)"
+  default     = "cron(5 * * * ? *)"
   description = "the aws cloudwatch event rule scheule expression that specifies when the scheduler runs. Default is 5 minuts past the hour. for debugging use 'rate(5 minutes)'. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
 }
 
 variable "tag" {
-  default = "schedule"
+  default     = "schedule"
   description = "the tag name used on the EC2 or RDS instance to contain the schedule json string for the instance."
 }
 
 variable "schedule_tag_force" {
-  type = "string"
-  default = "false"
+  type        = string
+  default     = "false"
   description = "Whether to force the EC2 or RDS instance to have the default schedule tag is no schedule tag exists for the instance."
 }
 
 variable "exclude" {
-  default = ""
+  default     = ""
   description = "common separated list of EC2 and RDS instance ids to exclude from scheduling."
 }
 
 variable "default" {
-  default = "{\"mon\": {\"start\": 7, \"stop\": 20},\"tue\": {\"start\": 7, \"stop\": 20},\"wed\": {\"start\": 7, \"stop\": 20},\"thu\": {\"start\": 7, \"stop\": 20}, \"fri\": {\"start\": 7, \"stop\": 20}}"
+  default     = "{\"mon\": {\"start\": 7, \"stop\": 20},\"tue\": {\"start\": 7, \"stop\": 20},\"wed\": {\"start\": 7, \"stop\": 20},\"thu\": {\"start\": 7, \"stop\": 20}, \"fri\": {\"start\": 7, \"stop\": 20}}"
   description = "the default schedule tag containing json schedule information to add to instance when schedule_tag_force set to true."
 }
 
 variable "time" {
-  default = "gmt"
+  default     = "gmt"
   description = "timezone to use for scheduler. Can be 'local', 'gmt' or an Olson timezone from https://gist.github.com/ykessler/3349954. default is 'gmt'. local time is for the AWS region."
 }
 
 variable "ec2_schedule" {
-  type = "string"
-  default = "true"
+  type        = string
+  default     = "true"
   description = "Whether to do scheduling for EC2 instances."
 }
 
 variable "rds_schedule" {
-  type = "string"
-  default = "true"
+  type        = string
+  default     = "true"
   description = "Whether to do scheduling for RDS instances."
 }
 
 variable "security_group_ids" {
-  type = "list"
-  default = []
+  type        = list(string)
+  default     = []
   description = "list of the vpc security groups to run lambda scheduler in."
 }
 
 variable "subnet_ids" {
-  type = "list"
-  default = []
+  type        = list(string)
+  default     = []
   description = "list of subnet_ids that the scheduler runs in."
 }
 
 variable "resource_name_prefix" {
-  default = ""
+  default     = ""
   description = "a prefix to apply to resource names created by this module."
 }


### PR DESCRIPTION
terraform 0.11 is deprecated since 2019:
https://www.hashicorp.com/blog/deprecating-terraform-0-11-support-in-terraform-providers/

upgrade according to the official doc:
https://www.terraform.io/upgrade-guides/0-12.html